### PR TITLE
(#2) Add hook package to cleanup desktop shortcuts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,82 @@
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+# nuget/chocolatey packages
+*.nupkg

--- a/src/cleanup-desktop-shortcuts.hook/cleanup-desktop-shortcuts.hook.nuspec
+++ b/src/cleanup-desktop-shortcuts.hook/cleanup-desktop-shortcuts.hook.nuspec
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>cleanup-desktop-shortcuts.hook</id>
+    <version>0.0.1-pre</version>
+    <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-hooks/src/cleanup-desktop-shortcuts.hook</packageSourceUrl>
+    <owners>Chocolatey Community, TheCakeIsNaOH</owners>
+    <title>Cleanup Desktop Shortcuts (Hook)</title>
+    <authors>Chocolatey Community, TheCakeIsNaOH</authors>
+    <projectUrl>https://github.com/chocolatey-community/chocolatey-hooks/src/cleanup-desktop-shortcuts.hook</projectUrl>
+    <!--<iconUrl>http://rawcdn.githack.com/__REPLACE_YOUR_REPO__/master/icons/cleanup-desktop-shortcuts.hook.png</iconUrl>-->
+    <copyright>2022 Chocolatey Community</copyright>
+    <licenseUrl>https://github.com/chocolatey-community/chocolatey-hooks/LICENSE.md</licenseUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <projectSourceUrl>https://github.com/chocolatey-community/chocolatey-hooks/src/cleanup-desktop-shortcuts.hook</projectSourceUrl>
+    <!--<docsUrl>TODO</docsUrl>-->
+    <!--<mailingListUrl>TODO</mailingListUrl>-->
+    <bugTrackerUrl>https://github.com/chocolatey-community/chocolatey-hooks/issues</bugTrackerUrl>
+    <tags>Shortcuts Hook</tags>
+    <summary>Remove desktop shortcuts created while installing packages.</summary>
+    <description>This hook package adds scripts that remove desktop shortcuts that are added to the global
+and user desktops during the process of installing Chocolatey packages. This is accomplished via a pre install
+hook that gets prexisting desktop shortcuts before install, and a post install hook that removes any shortcuts
+added while the `chocolateyInstall.ps1` is running. 
+
+## Warning
+Any shortcuts created outside of Chocolatey while a `chocolateyInstall.ps1` is running, may be removed in addition
+to any shortcuts created by the package. This is because this hook checks for all shortcuts added to the desktop,
+and does not have a way of filtering to only those that are created by the package.</description>
+    <releaseNotes>0.0.1-pre: Initial Release</releaseNotes>
+    <dependencies>
+      <dependency id="chocolatey" version="1.2.0" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="hook\**" target="hook" />
+  </files>
+</package>

--- a/src/cleanup-desktop-shortcuts.hook/cleanup-desktop-shortcuts.hook.nuspec
+++ b/src/cleanup-desktop-shortcuts.hook/cleanup-desktop-shortcuts.hook.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>cleanup-desktop-shortcuts.hook</id>
-    <version>0.0.1-pre</version>
+    <version>0.1.0-alpha-20221103</version>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-hooks/src/cleanup-desktop-shortcuts.hook</packageSourceUrl>
     <owners>Chocolatey Community, TheCakeIsNaOH</owners>
     <title>Cleanup Desktop Shortcuts (Hook)</title>

--- a/src/cleanup-desktop-shortcuts.hook/cleanup-desktop-shortcuts.hook.nuspec
+++ b/src/cleanup-desktop-shortcuts.hook/cleanup-desktop-shortcuts.hook.nuspec
@@ -28,7 +28,7 @@ added while the `chocolateyInstall.ps1` is running.
 Any shortcuts created outside of Chocolatey while a `chocolateyInstall.ps1` is running, may be removed in addition
 to any shortcuts created by the package. This is because this hook checks for all shortcuts added to the desktop,
 and does not have a way of filtering to only those that are created by the package.</description>
-    <releaseNotes>0.0.1-pre: Initial Release</releaseNotes>
+    <releaseNotes>0.1.0-alpha-20221103: Initial Release</releaseNotes>
     <dependencies>
       <dependency id="chocolatey" version="1.2.0" />
     </dependencies>

--- a/src/cleanup-desktop-shortcuts.hook/hook/post-install-all.ps1
+++ b/src/cleanup-desktop-shortcuts.hook/hook/post-install-all.ps1
@@ -1,0 +1,33 @@
+﻿if (-not $packageScript) {
+    #Warning was provided in pre-install script
+    return
+}
+
+if ([string]::IsNullOrEmpty([Environment]::GetFolderPath("DesktopDirectory"))) {
+    Write-Warning "Skipping cleanup because user desktop directory cannot be found"
+    return
+}
+
+[array]$global:cleanup_desktop_shortcuts_hook_post_shortcuts = Get-Childitem -Path ([environment]::GetFolderPath("DesktopDirectory")) -Filter "*.lnk"
+
+if (Test-ProcessAdminRights) {
+    if ([string]::IsNullOrEmpty([Environment]::GetFolderPath("CommonDesktopDirectory"))) {
+        Write-Warning "System wide desktop directory cannot be found, something went wrong."
+        Write-Warning "Skipping cleanup of desktop shortcuts"
+        return
+    }
+    $global:cleanup_desktop_shortcuts_hook_post_shortcuts += Get-Childitem -Path ([environment]::GetFolderPath("CommonDesktopDirectory")) -Filter "*.lnk"
+} else {
+    Write-Host "Not cleaning desktop shortcuts from the system wide desktop directory as script is not running with Admin rights."
+}
+
+foreach ($postshortcut in $cleanup_desktop_shortcuts_hook_post_shortcuts) {
+    if (($null -ne $cleanup_desktop_shortcuts_hook_pre_shortcuts)) {
+        if ($cleanup_desktop_shortcuts_hook_pre_shortcuts.name.Contains($postshortcut.name)) {
+            Write-Debug "'$($postshortcut.name)' existed before install script run, ignoring"
+            continue;
+        }
+    }
+    Write-Host "Removing '$($postshortcut.name)'"
+    Remove-Item -Path $postshortcut.fullname
+}

--- a/src/cleanup-desktop-shortcuts.hook/hook/post-install-all.ps1
+++ b/src/cleanup-desktop-shortcuts.hook/hook/post-install-all.ps1
@@ -8,7 +8,7 @@ if ([string]::IsNullOrEmpty([Environment]::GetFolderPath("DesktopDirectory"))) {
     return
 }
 
-[array]$global:cleanup_desktop_shortcuts_hook_post_shortcuts = Get-Childitem -Path ([environment]::GetFolderPath("DesktopDirectory")) -Filter "*.lnk"
+$global:CleanupDesktopShortcutsHook.PostShortcuts = @(Get-Childitem -Path ([environment]::GetFolderPath("DesktopDirectory")) -Filter "*.lnk")
 
 if (Test-ProcessAdminRights) {
     if ([string]::IsNullOrEmpty([Environment]::GetFolderPath("CommonDesktopDirectory"))) {
@@ -16,18 +16,18 @@ if (Test-ProcessAdminRights) {
         Write-Warning "Skipping cleanup of desktop shortcuts"
         return
     }
-    $global:cleanup_desktop_shortcuts_hook_post_shortcuts += Get-Childitem -Path ([environment]::GetFolderPath("CommonDesktopDirectory")) -Filter "*.lnk"
+    $global:CleanupDesktopShortcutsHook.PostShortcuts += @(Get-Childitem -Path ([environment]::GetFolderPath("CommonDesktopDirectory")) -Filter "*.lnk")
 } else {
     Write-Host "Not cleaning desktop shortcuts from the system wide desktop directory as script is not running with Admin rights."
 }
 
-foreach ($postshortcut in $cleanup_desktop_shortcuts_hook_post_shortcuts) {
-    if (($null -ne $cleanup_desktop_shortcuts_hook_pre_shortcuts)) {
-        if ($cleanup_desktop_shortcuts_hook_pre_shortcuts.name.Contains($postshortcut.name)) {
-            Write-Debug "'$($postshortcut.name)' existed before install script run, ignoring"
+foreach ($postshortcut in $CleanupDesktopShortcutsHook.PostShortcuts) {
+    if ($CleanupDesktopShortcutsHook.PreShortcuts) {
+        if ($CleanupDesktopShortcutsHook.PreShortcuts.fullname.Contains($postshortcut.fullname)) {
+            Write-Debug "'$($postshortcut.fullname)' existed before install script run, ignoring"
             continue;
         }
     }
-    Write-Host "Removing '$($postshortcut.name)'"
+    Write-Host "Removing '$($postshortcut.fullname)'"
     Remove-Item -Path $postshortcut.fullname
 }

--- a/src/cleanup-desktop-shortcuts.hook/hook/pre-install-all.ps1
+++ b/src/cleanup-desktop-shortcuts.hook/hook/pre-install-all.ps1
@@ -1,0 +1,19 @@
+﻿if (-not $packageScript) {
+    Write-Host "Skipping Cleanup of Desktop Shortcuts as there is no install script for this package"
+    return
+}
+
+if ([string]::IsNullOrEmpty([Environment]::GetFolderPath("DesktopDirectory"))) {
+    Write-Warning "User desktop directory cannot be found, is Chocolatey running as SYSTEM?"
+    return
+}
+
+[array]$global:cleanup_desktop_shortcuts_hook_pre_shortcuts = Get-Childitem -Path ([environment]::GetFolderPath("DesktopDirectory")) -Filter "*.lnk"
+
+if (Test-ProcessAdminRights) {
+    if ([string]::IsNullOrEmpty([Environment]::GetFolderPath("CommonDesktopDirectory"))) {
+        Write-Warning "System wide desktop directory cannot be found, something went wrong."
+        return
+    }
+    $global:cleanup_desktop_shortcuts_hook_pre_shortcuts += Get-Childitem -Path ([environment]::GetFolderPath("CommonDesktopDirectory")) -Filter "*.lnk"
+}

--- a/src/cleanup-desktop-shortcuts.hook/hook/pre-install-all.ps1
+++ b/src/cleanup-desktop-shortcuts.hook/hook/pre-install-all.ps1
@@ -8,12 +8,14 @@ if ([string]::IsNullOrEmpty([Environment]::GetFolderPath("DesktopDirectory"))) {
     return
 }
 
-[array]$global:cleanup_desktop_shortcuts_hook_pre_shortcuts = Get-Childitem -Path ([environment]::GetFolderPath("DesktopDirectory")) -Filter "*.lnk"
+$global:CleanupDesktopShortcutsHook = @{
+    PreShortcuts = @(Get-Childitem -Path ([environment]::GetFolderPath("DesktopDirectory")) -Filter "*.lnk")
+}
 
 if (Test-ProcessAdminRights) {
     if ([string]::IsNullOrEmpty([Environment]::GetFolderPath("CommonDesktopDirectory"))) {
         Write-Warning "System wide desktop directory cannot be found, something went wrong."
         return
     }
-    $global:cleanup_desktop_shortcuts_hook_pre_shortcuts += Get-Childitem -Path ([environment]::GetFolderPath("CommonDesktopDirectory")) -Filter "*.lnk"
+    $global:CleanupDesktopShortcutsHook.PreShortcuts += @(Get-Childitem -Path ([environment]::GetFolderPath("CommonDesktopDirectory")) -Filter "*.lnk")
 }


### PR DESCRIPTION
## Description Of Changes

Adds a hook package that removes desktop shortcuts created during package install scripts.

## Motivation and Context

See #2 

## Testing

1. Install a package without an install script `choco install balcon` and validate that it prints out a message that it is skipping desktop cleanup because there is not install script.
2. Clean the desktop of all shortcuts and install a package that creates a desktop shortcut (`choco install firefox`) and validate that the hook removes the shortcut.
3. Replace the firefox shortcut on the desktop, force install firefox  (`choco install firefox -f`) and validate that it does not remove the recreated shortcut.
4. Install packages with the firefox shortcut still on the desktop, and validate that it removes shortcuts from when multiple packages are installed with one command (`choco install balabolka foobar200`)

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [x] PowerShell code changes.

## Related Issue

Fixes #2

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [x] PowerShell v2 compatibility checked.