### PR TITLE
(#9) Adds Jenkins-Set-Prefix Hook Package

### DIFF
--- a/src/jenkins-set-prefix.hook/hook/post-install-jenkins.ps1
+++ b/src/jenkins-set-prefix.hook/hook/post-install-jenkins.ps1
@@ -1,0 +1,33 @@
+$ErrorActionPreference = "Stop"
+
+# Though recent Jenkins doesn't support any such systems...
+# If we are running on a system that doesn't have $PSScriptRoot, define it
+if (-not $PSScriptRoot) {
+    $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Definition -Parent
+}
+
+$Prefix = Get-Content -Path $PSScriptRoot\prefixvalue.txt
+
+# Get the path to the XML config file
+$RegistryPath = "HKLM:\SOFTWARE\Jenkins\InstalledProducts\Jenkins"
+if (Test-Path $RegistryPath) {
+    $InstallDirectory = Get-ItemPropertyValue -Path $RegistryPath -Name "InstallLocation"
+    $XmlPath = Join-Path $InstallDirectory "Jenkins.xml"
+} else {
+    throw "Jenkins is not installed correctly."
+}
+
+# If it's missing or different, add the prefix to the config arguments
+if (Test-Path $XmlPath) {
+    [xml]$JenkinsXml = Get-Content $XmlPath
+
+    if ($JenkinsXml.SelectSingleNode("/service/arguments")."#text" -notmatch "--prefix=/$Prefix") {
+        $JenkinsXml.SelectSingleNode("/service/arguments")."#text" = $JenkinsXml.SelectSingleNode("/service/arguments")."#text" -replace "\s*--prefix=/.+?\b", ""
+        $JenkinsXml.SelectSingleNode("/service/arguments")."#text" += " --prefix=/$Prefix"
+        $JenkinsXml.Save($XmlPath)
+    }
+} else {
+    throw "Could not find '$XmlPath'"
+}
+
+Restart-Service Jenkins

--- a/src/jenkins-set-prefix.hook/jenkins-set-prefix.hook.nuspec
+++ b/src/jenkins-set-prefix.hook/jenkins-set-prefix.hook.nuspec
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>jenkins-set-prefix.hook</id>
+    <version>1.0.0</version>
+    <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-hooks/tree/main/src/jenkins-set-prefix.hook</packageSourceUrl>
+    <owners>Chocolatey Community, jpruskin</owners>
+    <title>Set Jenkins Prefix (Hook)</title>
+    <authors>Chocolatey Community, jpruskin</authors>
+    <projectUrl>https://github.com/chocolatey-community/chocolatey-hooks/tree/main/src/jenkins-set-prefix.hook</projectUrl>
+    <copyright>2023 Chocolatey Community</copyright>
+    <licenseUrl>https://github.com/chocolatey-community/chocolatey-hooks/blob/main/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <projectSourceUrl>https://github.com/chocolatey-community/chocolatey-hooks/tree/main/src/jenkins-set-prefix.hook</projectSourceUrl>
+    <bugTrackerUrl>https://github.com/chocolatey-community/chocolatey-hooks/issues</bugTrackerUrl>
+    <tags>Jenkins Hook</tags>
+    <summary>Update Jenkins installations to use a Prefix.</summary>
+    <description>Due to the way Jenkins' MSI installs, changes to the Jenkins.xml configuration file can be unset (though backed up).
+
+This hook sets the Prefix value after every installation of Jenkins, ensuring that paths won't break unexpectedly.
+
+## Package Parameters
+
+* `/Prefix` - Sets the value of the prefix to use. Defaults to `jenkins`.
+
+These parameters can be passed as follows:
+
+`choco install jenkins-set-prefix.hook --parameters="/Prefix=ci"`</description>
+    <dependencies>
+      <dependency id="chocolatey" version="1.2.0" /><!-- Required for Hooks to exist -->
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="hook\**" target="hook" />
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/src/jenkins-set-prefix.hook/tools/chocolateyInstall.ps1
+++ b/src/jenkins-set-prefix.hook/tools/chocolateyInstall.ps1
@@ -1,0 +1,20 @@
+$ErrorActionPreference = "Stop"
+
+# If we are running on a system that doesn't have $PSScriptRoot, define it
+if (-not $PSScriptRoot) {
+    $PSScriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Definition
+}
+
+# If a parameter is provided, set a file to ensure we don't lose the prefix we intend to use
+$Params = Get-PackageParameters
+$VariableFile = Join-Path $PSScriptRoot "..\hook\prefixvalue.txt"
+
+$Prefix = if ($Params.ContainsKey("Prefix")) {
+    $Params["Prefix"]
+} elseif (Test-Path $VariableFile) {
+    Get-Content $VariableFile
+} else {
+    "jenkins"
+}
+
+Set-Content -Path $VariableFile -Value $Prefix.TrimStart("/")


### PR DESCRIPTION
Due to the way Jenkins' MSI installs, changes to the Jenkins.xml configuration file can be unset (though backed up).

This hook sets the Prefix value after every installation of Jenkins, ensuring that paths won't break unexpectedly.

There is a parameter (`/prefix`) that can be passed to set the path you want, though it defaults to `jenkins` (e.g. accessing Jenkins via `yoursitehere.local/jenkins`).

I considered having a blank default, and removing the prefix if you didn't provide one, but decided that anyone who ran `choco install jenkins-set-prefix.hook` probably _did_ want a prefix of some kind.

Additional consideration: Should this run the same logic on install, such that people can use it to set a prefix on an already installed Jenkins instance without running `choco install jenkins --force` (or waiting for an upgrade)? If so, I'd split bits into a function file. This would be, I think, similar to how post-install-all packages end up running their own logic, so seems somewhat supported already.